### PR TITLE
Give landing page a visual uplift

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,25 +24,27 @@
 <style>
   :root {
     color-scheme: light;
-    --page-bg: #f7f7f7;
-    --card-bg: #ffffff;
-    --ink: #111111;
-    --ink-muted: rgba(17, 17, 17, 0.72);
-    --ink-soft: rgba(17, 17, 17, 0.6);
-    --focus-ring: #111111;
-    --shadow-base: 0 1px 0 rgba(0, 0, 0, 0.06);
-    --shadow-hover: 0 6px 18px rgba(17, 17, 17, 0.12);
-    --pill-radius: 10px;
-    --teal-pill: rgba(79, 224, 210, 0.2);
-    --teal-icon: #2aa89e;
-    --magenta-pill: rgba(255, 90, 183, 0.2);
-    --magenta-icon: #d6459a;
-    --lime-pill: rgba(183, 255, 90, 0.22);
-    --lime-icon: #5da827;
-    --orange-pill: rgba(255, 166, 82, 0.22);
-    --orange-icon: #d97706;
-    --slate-pill: rgba(52, 64, 84, 0.22);
-    --slate-icon: #334155;
+    --page-bg: #f8f3ea;
+    --card-bg: rgba(255, 252, 246, 0.88);
+    --card-bg-strong: #fffaf1;
+    --ink: #17120d;
+    --ink-muted: rgba(23, 18, 13, 0.7);
+    --ink-soft: rgba(23, 18, 13, 0.58);
+    --line: rgba(79, 55, 31, 0.13);
+    --focus-ring: #17120d;
+    --shadow-base: 0 1px 0 rgba(79, 55, 31, 0.08), 0 18px 48px rgba(97, 66, 34, 0.08);
+    --shadow-hover: 0 18px 42px rgba(97, 66, 34, 0.16), 0 1px 0 rgba(79, 55, 31, 0.1);
+    --pill-radius: 14px;
+    --teal-pill: rgba(44, 199, 190, 0.16);
+    --teal-icon: #138b84;
+    --magenta-pill: rgba(242, 86, 155, 0.15);
+    --magenta-icon: #bb337d;
+    --lime-pill: rgba(151, 217, 70, 0.18);
+    --lime-icon: #548d20;
+    --orange-pill: rgba(255, 157, 68, 0.2);
+    --orange-icon: #bb5e0a;
+    --slate-pill: rgba(82, 101, 123, 0.16);
+    --slate-icon: #34495f;
   }
 
   *, *::before, *::after {
@@ -52,13 +54,27 @@
   body {
     margin: 0;
     min-height: 100vh;
-    background: var(--page-bg);
+    background:
+      radial-gradient(circle at top left, rgba(255, 157, 68, 0.26), transparent 28rem),
+      radial-gradient(circle at 85% 12%, rgba(44, 199, 190, 0.22), transparent 24rem),
+      linear-gradient(135deg, #fffaf1 0%, var(--page-bg) 44%, #efe8dc 100%);
     color: var(--ink);
-    font-family: 'Segoe UI', 'Helvetica Neue', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    font-family: Inter, ui-sans-serif, 'Segoe UI', 'Helvetica Neue', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
     font-size: 16px;
     line-height: 1.6;
     display: flex;
     flex-direction: column;
+  }
+
+  body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background-image: linear-gradient(rgba(23, 18, 13, 0.035) 1px, transparent 1px), linear-gradient(90deg, rgba(23, 18, 13, 0.035) 1px, transparent 1px);
+    background-size: 44px 44px;
+    -webkit-mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), transparent 72%);
+    mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), transparent 72%);
   }
 
   a {
@@ -67,11 +83,62 @@
     outline: none;
   }
 
+  .site-nav {
+    width: min(1040px, 100%);
+    margin: 0 auto;
+    padding: clamp(16px, 4vw, 30px) clamp(16px, 6vw, 32px) 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  .brand-mark {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 0.85rem;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .brand-mark::before {
+    content: "";
+    width: 14px;
+    height: 14px;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #ff9d44, #2cc7be 58%, #f2569b);
+    box-shadow: 0 0 0 6px rgba(255, 157, 68, 0.13);
+  }
+
+  .nav-links {
+    display: flex;
+    align-items: center;
+    gap: clamp(10px, 3vw, 18px);
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    color: var(--ink-muted);
+    font-size: 0.9rem;
+    font-weight: 700;
+  }
+
+  .nav-links a {
+    border-bottom: 1px solid transparent;
+    transition: color 0.18s ease, border-color 0.18s ease;
+  }
+
+  .nav-links a:hover,
+  .nav-links a:focus-visible {
+    color: var(--ink);
+    border-color: currentColor;
+  }
+
   main {
     flex: 1 0 auto;
     width: min(1040px, 100%);
     margin: 0 auto;
-    padding: clamp(24px, 6vw, 64px) clamp(16px, 6vw, 32px) clamp(64px, 8vw, 96px);
+    padding: clamp(30px, 6vw, 72px) clamp(16px, 6vw, 32px) clamp(64px, 8vw, 96px);
   }
 
   footer {
@@ -79,7 +146,7 @@
     padding: 32px clamp(16px, 6vw, 32px) 56px;
     text-align: center;
     font-size: 0.82rem;
-    color: rgba(17, 17, 17, 0.5);
+    color: rgba(23, 18, 13, 0.5);
   }
 
   footer a {
@@ -91,27 +158,79 @@
 
   .layout-shell {
     display: grid;
-    gap: clamp(28px, 6vw, 48px);
+    gap: clamp(28px, 6vw, 52px);
   }
 
   .page-head {
+    position: relative;
     display: grid;
-    gap: 0.6rem;
-    max-width: 34ch;
+    gap: 1rem;
+    max-width: 780px;
+    padding: clamp(22px, 5vw, 40px);
+    background: linear-gradient(135deg, rgba(255, 250, 241, 0.82), rgba(255, 255, 255, 0.5));
+    border: 1px solid var(--line);
+    border-radius: clamp(24px, 5vw, 36px);
+    box-shadow: var(--shadow-base);
+    overflow: hidden;
+  }
+
+  .page-head::after {
+    content: "";
+    position: absolute;
+    width: 170px;
+    height: 170px;
+    right: -58px;
+    top: -72px;
+    border-radius: 999px;
+    background: radial-gradient(circle, rgba(242, 86, 155, 0.2), transparent 68%);
+  }
+
+  .eyebrow {
+    margin: 0;
+    color: var(--ink-muted);
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
   }
 
   .page-head h1 {
+    position: relative;
     margin: 0;
-    font-size: clamp(22px, 4vw, 36px);
-    font-weight: 800;
-    line-height: 1.1;
+    max-width: 12ch;
+    font-size: clamp(46px, 10vw, 96px);
+    font-weight: 900;
+    letter-spacing: -0.075em;
+    line-height: 0.92;
   }
 
   .page-head p {
+    position: relative;
     margin: 0;
-    font-size: clamp(14px, 2.4vw, 18px);
+    font-size: clamp(17px, 2.4vw, 22px);
     color: var(--ink-muted);
-    max-width: 42ch;
+    max-width: 48ch;
+  }
+
+  .hero-actions {
+    position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 0.3rem;
+  }
+
+  .hero-chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: 36px;
+    padding: 0 14px;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.54);
+    color: var(--ink-muted);
+    font-size: 0.86rem;
+    font-weight: 800;
   }
 
   .link-hub {
@@ -120,7 +239,7 @@
 
   .links-grid {
     display: grid;
-    gap: clamp(12px, 4vw, 16px);
+    gap: clamp(12px, 4vw, 18px);
     list-style: none;
     padding: 0;
     margin: 0;
@@ -133,23 +252,48 @@
     display: flex;
     align-items: flex-start;
     gap: clamp(12px, 4vw, 18px);
-    padding: clamp(16px, 4vw, 24px) clamp(18px, 5vw, 28px);
+    height: 100%;
+    padding: clamp(18px, 4vw, 26px) clamp(18px, 5vw, 28px);
     background: var(--card-bg);
-    border-radius: clamp(14px, 4vw, 18px);
+    border: 1px solid var(--line);
+    border-radius: clamp(20px, 4vw, 28px);
     box-shadow: var(--shadow-base);
     min-height: 56px;
-    transition: transform 0.18s ease, box-shadow 0.18s ease;
+    overflow: hidden;
+    backdrop-filter: blur(18px);
+    transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+  }
+
+  .link-card::after {
+    content: "↗";
+    position: absolute;
+    top: 18px;
+    right: 20px;
+    color: var(--icon-color);
+    font-size: 1rem;
+    font-weight: 900;
+    opacity: 0;
+    transform: translate(-4px, 4px);
+    transition: opacity 0.18s ease, transform 0.18s ease;
   }
 
   .link-card:hover {
-    transform: translateY(-2px);
+    transform: translateY(-4px);
     box-shadow: var(--shadow-hover);
+    border-color: rgba(79, 55, 31, 0.22);
+    background: var(--card-bg-strong);
+  }
+
+  .link-card:hover::after,
+  .link-card:focus-visible::after {
+    opacity: 1;
+    transform: none;
   }
 
   .link-card:focus-visible {
     outline: 2px solid var(--focus-ring);
     outline-offset: 4px;
-    transform: translateY(-2px);
+    transform: translateY(-4px);
     box-shadow: var(--shadow-hover);
   }
 
@@ -161,8 +305,8 @@
 
   .icon-pill {
     flex: 0 0 auto;
-    width: clamp(32px, 6vw, 40px);
-    height: clamp(32px, 6vw, 40px);
+    width: clamp(38px, 6vw, 48px);
+    height: clamp(38px, 6vw, 48px);
     border-radius: var(--pill-radius);
     background: var(--pill-bg);
     display: inline-flex;
@@ -171,8 +315,8 @@
   }
 
   .icon-pill svg {
-    width: clamp(18px, 4.5vw, 22px);
-    height: clamp(18px, 4.5vw, 22px);
+    width: clamp(20px, 4.5vw, 24px);
+    height: clamp(20px, 4.5vw, 24px);
     fill: none;
   }
 
@@ -195,52 +339,70 @@
     max-width: 38ch;
     flex: 1;
     min-width: 0;
+    padding-right: 20px;
   }
 
   .card-title {
     margin: 0;
-    font-size: clamp(20px, 3.8vw, 32px);
-    font-weight: 800;
-    line-height: 1.1;
+    font-size: clamp(24px, 4.2vw, 38px);
+    font-weight: 900;
+    letter-spacing: -0.045em;
+    line-height: 1;
     word-break: break-word;
   }
 
   .card-subtitle {
     margin: 0;
-    font-size: clamp(13px, 2.5vw, 16px);
-    font-weight: 600;
-    letter-spacing: 0.04em;
+    font-size: clamp(12px, 2.2vw, 14px);
+    font-weight: 800;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
     color: var(--ink-muted);
     word-break: break-word;
   }
 
   .card-caption {
     margin: 0;
-    font-size: clamp(14px, 2.4vw, 18px);
+    font-size: clamp(14px, 2.4vw, 17px);
     color: var(--ink-soft);
     line-height: 1.4;
   }
 
-  @media (min-width: 1024px) {
+  @media (min-width: 820px) {
     .links-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: clamp(24px, 3vw, 32px);
+      gap: clamp(18px, 3vw, 28px);
     }
 
-    .links-grid li:nth-child(odd) .link-card {
-      justify-self: flex-start;
+    .links-grid li:first-child {
+      grid-column: span 2;
     }
 
-    .links-grid li:nth-child(even) .link-card {
-      justify-self: flex-start;
+    .links-grid li:first-child .link-card {
+      align-items: center;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .site-nav {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .nav-links {
+      justify-content: flex-start;
     }
   }
 
   @media (prefers-reduced-motion: reduce) {
     .link-card,
+    .link-card::after,
+    .nav-links a {
+      transition: none !important;
+    }
+
     .link-card:hover,
     .link-card:focus-visible {
-      transition: none !important;
       transform: none !important;
     }
   }
@@ -256,11 +418,19 @@
 </script>
 </head>
 <body class="{{ page.body_class | default: '' }}">
+<header class="site-nav" aria-label="Site">
+  <a class="brand-mark" href="{{ '/' | relative_url }}">krwill.xyz</a>
+  <nav class="nav-links" aria-label="Quick links">
+    <a href="{{ '/notes/' | relative_url }}">Notes</a>
+    <a href="{{ '/photography/' | relative_url }}">Photos</a>
+    <a href="https://driftingforms.com" target="_blank" rel="noopener noreferrer">Shop</a>
+  </nav>
+</header>
 <main>
   <div class="layout-shell">
     {{ content }}
   </div>
 </main>
-<footer>All roads drift. © 2025 Kristopher Williams • Mukilteo, WA</footer>
+<footer>All roads drift. © 2026 Kristopher Williams • Mukilteo, WA</footer>
 </body>
 </html>

--- a/index.md
+++ b/index.md
@@ -6,8 +6,14 @@ body_class: landing
 ---
 
 <section class="page-head" aria-labelledby="page-title">
+  <p class="eyebrow">Artist / maker / observer</p>
   <h1 id="page-title">Kristopher Williams</h1>
-  <p>Artist and maker. Five doors: Shop, Life, Notes, Photos, Professional.</p>
+  <p>A warmer front door for originals, notes, photos, and the buttoned-up work. Pick a path and wander.</p>
+  <div class="hero-actions" aria-label="Site highlights">
+    <span class="hero-chip">Originals + prints</span>
+    <span class="hero-chip">Studio notes</span>
+    <span class="hero-chip">Field photos</span>
+  </div>
 </section>
 
 <nav class="link-hub" aria-label="Primary">


### PR DESCRIPTION
### Motivation
- Refresh the landing page to present a warmer, more intentional front door with stronger typography and layered visual treatments. 
- Surface primary navigation and clarifying hero content so visitors can quickly choose Notes, Photos, Shop, or the professional site. 
- Improve link-card affordances and spacing so the hub feels more like a tactile set of entry points.

### Description
- Reworked `_layouts/default.html` with new theme variables, warmer palette, layered radial/linear background, and a subtle grid overlay using `body::before` (added `-webkit-mask-image` for compatibility). 
- Added a persistent quick-link header (`.site-nav`, `.brand-mark`, `.nav-links`) and bumped the page typography to include `Inter`. 
- Restyled the hero and cards: increased `--pill-radius`, stronger shadows/hover (`--shadow-base`, `--shadow-hover`), glassy card surfaces with `backdrop-filter`, directional affordance (`.link-card::after`), and responsive grid adjustments. 
- Updated `index.md` hero copy by adding an eyebrow, a warmer intro paragraph, and highlight chips (`.hero-actions` / `.hero-chip`), and updated the footer year to 2026.

### Testing
- Ran `git diff --check` which returned no style errors and showed the intended changes. 
- Attempted `bundle exec jekyll build` but it failed because the environment lacked the Jekyll executable. 
- Attempted `bundle install` which failed due to upstream `rubygems.org` requests returning HTTP 403 through the environment proxy. 
- Attempts to install browser tooling (`npm install playwright-chromium` and `apt-get install chromium`) were blocked by the environment proxy returning HTTP 403, so visual regression screenshots/build verification could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c6effd5e88327b0a72a6e33e160f3)