### PR TITLE
Reframe homepage around identity and current work

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: "krwill.xyz"
 url: "https://krwill.xyz"
-description: "Artist and maker. Five doors: Shop, Life, Notes, Photos, Professional."
+description: "Artist. Engineer. Father. Builder of long-lived systems."
 social_image: /assets/social-card.svg
 theme: minima
 plugins: [jekyll-seo-tag]

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -204,6 +204,20 @@
     line-height: 0.92;
   }
 
+  .hero-home {
+    max-width: none;
+  }
+
+  .hero-home h1,
+  .content-head h1 {
+    max-width: 13ch;
+    font-size: clamp(42px, 8vw, 82px);
+  }
+
+  .content-head {
+    max-width: 900px;
+  }
+
   .page-head p {
     position: relative;
     margin: 0;
@@ -231,6 +245,136 @@
     color: var(--ink-muted);
     font-size: 0.86rem;
     font-weight: 800;
+  }
+
+  .hero-chip-link {
+    color: var(--ink);
+    transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+  }
+
+  .hero-chip-link:hover,
+  .hero-chip-link:focus-visible {
+    background: #fff;
+    border-color: rgba(79, 55, 31, 0.28);
+    transform: translateY(-2px);
+  }
+
+  .feature-panel {
+    display: grid;
+    gap: clamp(18px, 4vw, 28px);
+    padding: clamp(22px, 5vw, 34px);
+    background: rgba(255, 252, 246, 0.62);
+    border: 1px solid var(--line);
+    border-radius: clamp(22px, 5vw, 34px);
+    box-shadow: var(--shadow-base);
+  }
+
+  .section-kicker {
+    margin: 0;
+    color: var(--ink-muted);
+    font-size: 0.76rem;
+    font-weight: 900;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+  }
+
+  .section-heading {
+    display: flex;
+    justify-content: space-between;
+    gap: 18px;
+    align-items: end;
+  }
+
+  .section-heading h2 {
+    margin: 0.2rem 0 0;
+    font-size: clamp(30px, 5vw, 52px);
+    line-height: 0.98;
+    letter-spacing: -0.055em;
+  }
+
+  .section-heading > p {
+    margin: 0;
+    max-width: 34ch;
+    color: var(--ink-muted);
+    font-size: clamp(15px, 2.2vw, 18px);
+  }
+
+  .current-focus-grid,
+  .evidence-grid,
+  .principle-grid {
+    display: grid;
+    gap: clamp(14px, 3vw, 20px);
+  }
+
+  .focus-card,
+  .evidence-card,
+  .principle-grid article {
+    display: grid;
+    gap: 0.7rem;
+    padding: clamp(18px, 4vw, 26px);
+    background: var(--card-bg);
+    border: 1px solid var(--line);
+    border-radius: clamp(18px, 4vw, 26px);
+    box-shadow: 0 1px 0 rgba(79, 55, 31, 0.06);
+  }
+
+  .focus-card,
+  .evidence-card {
+    transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+  }
+
+  .focus-card:hover,
+  .focus-card:focus-visible,
+  .evidence-card:hover,
+  .evidence-card:focus-visible {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-hover);
+    border-color: rgba(79, 55, 31, 0.22);
+    background: var(--card-bg-strong);
+  }
+
+  .focus-card:focus-visible,
+  .evidence-card:focus-visible {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: 4px;
+  }
+
+  .focus-card-primary {
+    background:
+      radial-gradient(circle at top right, rgba(44, 199, 190, 0.18), transparent 16rem),
+      var(--card-bg-strong);
+  }
+
+  .evidence-card span {
+    color: var(--ink-muted);
+    font-size: 0.74rem;
+    font-weight: 900;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+
+  .evidence-card strong,
+  .principle-grid h2 {
+    margin: 0;
+    font-size: clamp(22px, 3.2vw, 30px);
+    line-height: 1.05;
+    letter-spacing: -0.04em;
+  }
+
+  .evidence-card p,
+  .principle-grid p,
+  .prose-panel > p {
+    margin: 0;
+    color: var(--ink-muted);
+  }
+
+  .prose-panel {
+    max-width: 900px;
+    font-size: clamp(17px, 2.3vw, 20px);
+  }
+
+  .principle-grid {
+    margin-top: 0.4rem;
   }
 
   .link-hub {
@@ -374,12 +518,39 @@
       gap: clamp(18px, 3vw, 28px);
     }
 
-    .links-grid li:first-child {
+    .explore-grid li:first-child {
       grid-column: span 2;
     }
 
-    .links-grid li:first-child .link-card {
+    .explore-grid li:first-child .link-card {
       align-items: center;
+    }
+
+    .current-focus-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .focus-card-primary {
+      grid-column: span 2;
+    }
+
+    .evidence-grid,
+    .principle-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (min-width: 980px) {
+    .focus-card-primary {
+      grid-row: span 2;
+    }
+
+    .evidence-grid {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    .principle-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }
 
@@ -392,17 +563,31 @@
     .nav-links {
       justify-content: flex-start;
     }
+
+    .section-heading {
+      align-items: start;
+      flex-direction: column;
+    }
   }
 
   @media (prefers-reduced-motion: reduce) {
     .link-card,
     .link-card::after,
+    .focus-card,
+    .evidence-card,
+    .hero-chip-link,
     .nav-links a {
       transition: none !important;
     }
 
     .link-card:hover,
-    .link-card:focus-visible {
+    .link-card:focus-visible,
+    .focus-card:hover,
+    .focus-card:focus-visible,
+    .evidence-card:hover,
+    .evidence-card:focus-visible,
+    .hero-chip-link:hover,
+    .hero-chip-link:focus-visible {
       transform: none !important;
     }
   }
@@ -421,9 +606,10 @@
 <header class="site-nav" aria-label="Site">
   <a class="brand-mark" href="{{ '/' | relative_url }}">krwill.xyz</a>
   <nav class="nav-links" aria-label="Quick links">
+    <a href="{{ '/atlas/' | relative_url }}">Atlas</a>
+    <a href="{{ '/artwork/' | relative_url }}">Artwork</a>
     <a href="{{ '/notes/' | relative_url }}">Notes</a>
     <a href="{{ '/photography/' | relative_url }}">Photos</a>
-    <a href="https://driftingforms.com" target="_blank" rel="noopener noreferrer">Shop</a>
   </nav>
 </header>
 <main>

--- a/artwork/index.md
+++ b/artwork/index.md
@@ -1,0 +1,36 @@
+---
+layout: default
+title: Artwork
+description: "Drifting Forms: original artwork exploring pattern, emergence, and human-machine collaboration."
+body_class: content-page artwork-page
+---
+
+<section class="page-head content-head" aria-labelledby="page-title">
+  <p class="eyebrow">Drifting Forms</p>
+  <h1 id="page-title">A weird collaboration between code, machines, paint, and mistakes.</h1>
+  <p>I use generative systems to discover structures I would not have drawn by hand, then work back into them with human judgment, physical texture, and the stubbornness of paint.</p>
+  <div class="hero-actions">
+    <a class="hero-chip hero-chip-link" href="https://driftingforms.com" target="_blank" rel="noopener noreferrer">Visit the shop</a>
+  </div>
+</section>
+
+<section class="feature-panel prose-panel">
+  <p>The shop is not the point of the work. The story is the point: teaching machines to make marks, watching them misunderstand, and then deciding which accidents deserve a human hand.</p>
+
+  <p>Drifting Forms is where the engineering brain and the studio brain meet. Algorithms provide pressure. Paint provides resistance. The finished pieces are records of that negotiation.</p>
+
+  <div class="principle-grid" aria-label="Artwork themes">
+    <article>
+      <h2>Pattern</h2>
+      <p>Repeated marks, emergent structures, and small variations that become larger fields.</p>
+    </article>
+    <article>
+      <h2>Collaboration</h2>
+      <p>Human-machine systems where neither side fully controls the final image.</p>
+    </article>
+    <article>
+      <h2>Materiality</h2>
+      <p>Digital starts, physical finishes, and the evidence of decisions made by hand.</p>
+    </article>
+  </div>
+</section>

--- a/atlas/index.md
+++ b/atlas/index.md
@@ -1,0 +1,33 @@
+---
+layout: default
+title: Atlas
+description: "A personal infrastructure system for organizing life, projects, data, and memory over decades."
+body_class: content-page atlas-page
+---
+
+<section class="page-head content-head" aria-labelledby="page-title">
+  <p class="eyebrow">Atlas</p>
+  <h1 id="page-title">A 30-year experiment in organizing a human life.</h1>
+  <p>Atlas is my private infrastructure for projects, memory, household rhythms, creative work, data, and the connective tissue between them. The personal data stays private. The philosophy can be public.</p>
+</section>
+
+<section class="feature-panel prose-panel">
+  <p>Most personal systems are built for a quarter, a job, or a single productivity method. Atlas is built around a longer question: what would it mean to maintain a living map of a person’s work, relationships, responsibilities, artifacts, and decisions over decades?</p>
+
+  <p>It is part archive, part operating system, part studio wall, and part maintenance ritual. The goal is not perfect capture. The goal is continuity: enough structure that future me can understand what mattered, what changed, and what still needs care.</p>
+
+  <div class="principle-grid" aria-label="Atlas principles">
+    <article>
+      <h2>Life is the domain model.</h2>
+      <p>Projects, notes, finances, family logistics, creative output, and home maintenance are not separate lives. They are one system with different surfaces.</p>
+    </article>
+    <article>
+      <h2>Memory needs infrastructure.</h2>
+      <p>Photos, files, decisions, and observations become more valuable when they can be found, connected, and revisited later.</p>
+    </article>
+    <article>
+      <h2>Durability beats novelty.</h2>
+      <p>Atlas is designed for tools and practices that can survive changing software, changing priorities, and changing versions of me.</p>
+    </article>
+  </div>
+</section>

--- a/index.md
+++ b/index.md
@@ -1,101 +1,168 @@
 ---
 layout: default
 title: Kristopher Williams
-description: "Artist and maker. Five doors: Shop, Life, Notes, Photos, Professional."
+description: "Artist. Engineer. Father. Builder of long-lived systems."
+og_description: "The public front door for Kristopher Williams: Atlas, Drifting Forms, notes, photography, and proof-of-life updates."
 body_class: landing
 ---
 
-<section class="page-head" aria-labelledby="page-title">
-  <p class="eyebrow">Artist / maker / observer</p>
-  <h1 id="page-title">Kristopher Williams</h1>
-  <p>A warmer front door for originals, notes, photos, and the buttoned-up work. Pick a path and wander.</p>
-  <div class="hero-actions" aria-label="Site highlights">
-    <span class="hero-chip">Originals + prints</span>
-    <span class="hero-chip">Studio notes</span>
-    <span class="hero-chip">Field photos</span>
+<section class="page-head hero-home" aria-labelledby="page-title">
+  <p class="eyebrow">Kristopher Williams</p>
+  <h1 id="page-title">Artist. Engineer. Father. Builder of long-lived systems.</h1>
+  <p>I make tools, images, archives, gardens, and rituals for paying attention over a lifetime. krwill.xyz is the public map of that work: what I am building, what I am learning, and where the energy is going now.</p>
+  <div class="hero-actions" aria-label="Identity facets">
+    <span class="hero-chip">Artist</span>
+    <span class="hero-chip">Engineer</span>
+    <span class="hero-chip">Father</span>
+    <span class="hero-chip">Systems builder</span>
   </div>
 </section>
 
-<nav class="link-hub" aria-label="Primary">
-  <ul class="links-grid">
-    <li>
-      <a class="link-card card-shop" href="https://driftingforms.com" target="_blank" rel="noopener noreferrer">
-        <span class="icon-pill" aria-hidden="true">
-          <svg viewBox="0 0 24 24">
-            <path d="M8 9.5V7a4 4 0 0 1 8 0v2.5" />
-            <path d="M6.5 9.5h11l-1 9h-9l-1-9Z" />
-            <line x1="10" y1="13" x2="14" y2="13" />
-          </svg>
-        </span>
-        <span class="text-group">
-          <span class="card-subtitle">→ Drifting Forms</span>
-          <span class="card-title">Shop</span>
-          <span class="card-caption">Originals + prints, straight from the wall.</span>
-        </span>
-      </a>
-    </li>
-    <li>
-      <a class="link-card card-life" href="https://instagram.com/krwillxyz" target="_blank" rel="noopener noreferrer">
-        <span class="icon-pill" aria-hidden="true">
-          <svg viewBox="0 0 24 24">
-            <path d="M12 18.8l-6-6.2a3.4 3.4 0 0 1 4.8-4.8l1.2 1.2 1.2-1.2a3.4 3.4 0 0 1 4.8 4.8Z" />
-          </svg>
-        </span>
-        <span class="text-group">
-          <span class="card-subtitle">→ Instagram (@krwillxyz)</span>
-          <span class="card-title">Life</span>
-          <span class="card-caption">Studio sparks, daily noise, odd joys.</span>
-        </span>
-      </a>
-    </li>
-    <li>
-      <a class="link-card card-notes" href="/notes/">
-        <span class="icon-pill" aria-hidden="true">
-          <svg viewBox="0 0 24 24">
-            <rect x="5.5" y="6.5" width="13" height="12" rx="2" />
-            <path d="M8.5 4.8h7" />
-            <path d="M8.5 11.2h6" />
-            <path d="M8.5 14.2h6" />
-          </svg>
-        </span>
-        <span class="text-group">
-          <span class="card-subtitle">→ Notes feed</span>
-          <span class="card-title">Notes</span>
-          <span class="card-caption">Ideas scribbled before they fade.</span>
-        </span>
-      </a>
-    </li>
-    <li>
-      <a class="link-card card-photos" href="/photography/">
-        <span class="icon-pill" aria-hidden="true">
-          <svg viewBox="0 0 24 24">
-            <path d="M6 8.5h12a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2Z" />
-            <path d="M9.5 7.5l1.1-2.2h2.8l1.1 2.2" />
-            <circle cx="12" cy="13.5" r="3" />
-          </svg>
-        </span>
-        <span class="text-group">
-          <span class="card-subtitle">→ Photography</span>
-          <span class="card-title">Photos</span>
-          <span class="card-caption">Frames I couldn’t leave buried.</span>
-        </span>
-      </a>
-    </li>
-    <li>
-      <a class="link-card card-pro" href="https://kristopherwilliams.com" target="_blank" rel="noopener noreferrer">
-        <span class="icon-pill" aria-hidden="true">
-          <svg viewBox="0 0 24 24">
-            <path d="M8 9V7.5a3 3 0 0 1 3-3h2a3 3 0 0 1 3 3V9" />
-            <path d="M5 10.5h14v7.5a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2Z" />
-            <path d="M5 13.5h14" />
-          </svg>
-        </span>
-        <span class="text-group">
-          <span class="card-subtitle">→ kristopherwilliams.com</span>
-          <span class="card-title">Professional</span>
-          <span class="card-caption">Résumé + projects, the buttoned-up me.</span>
-        </span>
-      </a>
-    </li>
-  </ul>
-</nav>
+<section class="feature-panel" aria-labelledby="current-focus-title">
+  <div class="section-kicker">Current focus</div>
+  <div class="current-focus-grid">
+    <a class="focus-card focus-card-primary" href="/atlas/">
+      <span class="card-subtitle">Atlas</span>
+      <span class="card-title">A 30-year experiment in organizing a human life.</span>
+      <span class="card-caption">Personal infrastructure for projects, memory, data, and the small recurring systems that make a life legible over decades.</span>
+    </a>
+    <a class="focus-card" href="/artwork/">
+      <span class="card-subtitle">Drifting Forms</span>
+      <span class="card-title">Teaching machines to draw, then painting on top of their mistakes.</span>
+      <span class="card-caption">Original artwork exploring pattern, emergence, and human-machine collaboration.</span>
+    </a>
+    <a class="focus-card" href="https://instagram.com/krwillxyz" target="_blank" rel="noopener noreferrer">
+      <span class="card-subtitle">Calvin</span>
+      <span class="card-title">The ongoing project of raising a curious human.</span>
+      <span class="card-caption">A reminder that the longest-running systems are built in public moments, private routines, and everyday attention.</span>
+    </a>
+  </div>
+</section>
+
+<section class="feature-panel" aria-labelledby="recent-work-title">
+  <div class="section-heading">
+    <div>
+      <p class="section-kicker">Recent work</p>
+      <h2 id="recent-work-title">Proof of life, not a feed.</h2>
+    </div>
+    <p>Small pieces of evidence from the studio, the codebase, the yard, and the archive.</p>
+  </div>
+  <div class="evidence-grid">
+    <a class="evidence-card" href="/artwork/">
+      <span>New painting</span>
+      <strong>Drifting Forms</strong>
+      <p>Generated structure, human correction, paint, texture, and the occasional beautiful accident.</p>
+    </a>
+    <a class="evidence-card" href="/atlas/">
+      <span>Atlas feature</span>
+      <strong>Life infrastructure</strong>
+      <p>Private tools becoming public philosophy: memory, projects, and durable personal systems.</p>
+    </a>
+    <a class="evidence-card" href="https://instagram.com/krwillxyz" target="_blank" rel="noopener noreferrer">
+      <span>Garden wall</span>
+      <strong>Built environments</strong>
+      <p>Physical systems count too: stone, soil, weather, maintenance, and patience.</p>
+    </a>
+    <a class="evidence-card" href="/notes/">
+      <span>Plotter experiment</span>
+      <strong>Machine marks</strong>
+      <p>Notes from the edge between code, drawing, tools, and the stubborn material world.</p>
+    </a>
+  </div>
+</section>
+
+<section class="feature-panel" aria-labelledby="explore-title">
+  <div class="section-heading">
+    <div>
+      <p class="section-kicker">Explore</p>
+      <h2 id="explore-title">Choose a door after you know the person.</h2>
+    </div>
+  </div>
+  <nav class="link-hub" aria-label="Primary destinations">
+    <ul class="links-grid explore-grid">
+      <li>
+        <a class="link-card card-shop" href="/artwork/">
+          <span class="icon-pill" aria-hidden="true">
+            <svg viewBox="0 0 24 24">
+              <path d="M5 19c3.8-1 5.1-3.1 5.8-6.1" />
+              <path d="M12 5c2.9 1.1 5.1 3.2 6.5 6.4" />
+              <path d="M8.5 9.5c2.7 1.9 5 4.1 6.8 6.7" />
+            </svg>
+          </span>
+          <span class="text-group">
+            <span class="card-subtitle">Drifting Forms</span>
+            <span class="card-title">Artwork</span>
+            <span class="card-caption">The story, gallery path, and shop for original work.</span>
+          </span>
+        </a>
+      </li>
+      <li>
+        <a class="link-card card-pro" href="/atlas/">
+          <span class="icon-pill" aria-hidden="true">
+            <svg viewBox="0 0 24 24">
+              <path d="M4.5 7.5h15" />
+              <path d="M4.5 12h15" />
+              <path d="M4.5 16.5h15" />
+              <path d="M8 4.5v15" />
+              <path d="M16 4.5v15" />
+            </svg>
+          </span>
+          <span class="text-group">
+            <span class="card-subtitle">Personal infrastructure</span>
+            <span class="card-title">Atlas</span>
+            <span class="card-caption">The philosophy behind organizing life over decades.</span>
+          </span>
+        </a>
+      </li>
+      <li>
+        <a class="link-card card-photos" href="/photography/">
+          <span class="icon-pill" aria-hidden="true">
+            <svg viewBox="0 0 24 24">
+              <path d="M6 8.5h12a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2Z" />
+              <path d="M9.5 7.5l1.1-2.2h2.8l1.1 2.2" />
+              <circle cx="12" cy="13.5" r="3" />
+            </svg>
+          </span>
+          <span class="text-group">
+            <span class="card-subtitle">Field notes</span>
+            <span class="card-title">Photography</span>
+            <span class="card-caption">Frames I couldn’t leave buried.</span>
+          </span>
+        </a>
+      </li>
+      <li>
+        <a class="link-card card-notes" href="/notes/">
+          <span class="icon-pill" aria-hidden="true">
+            <svg viewBox="0 0 24 24">
+              <rect x="5.5" y="6.5" width="13" height="12" rx="2" />
+              <path d="M8.5 4.8h7" />
+              <path d="M8.5 11.2h6" />
+              <path d="M8.5 14.2h6" />
+            </svg>
+          </span>
+          <span class="text-group">
+            <span class="card-subtitle">Thinking aloud</span>
+            <span class="card-title">Notes</span>
+            <span class="card-caption">Ideas scribbled before they fade.</span>
+          </span>
+        </a>
+      </li>
+      <li>
+        <a class="link-card card-life" href="https://kristopherwilliams.com" target="_blank" rel="noopener noreferrer">
+          <span class="icon-pill" aria-hidden="true">
+            <svg viewBox="0 0 24 24">
+              <path d="M8 9V7.5a3 3 0 0 1 3-3h2a3 3 0 0 1 3 3V9" />
+              <path d="M5 10.5h14v7.5a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2Z" />
+              <path d="M5 13.5h14" />
+            </svg>
+          </span>
+          <span class="text-group">
+            <span class="card-subtitle">Buttoned-up context</span>
+            <span class="card-title">About</span>
+            <span class="card-caption">Professional history, résumé, and project background.</span>
+          </span>
+        </a>
+      </li>
+    </ul>
+  </nav>
+</section>


### PR DESCRIPTION
### Motivation
- The homepage needed to lead with a clear personal identity and current priorities rather than a directory of site sections. 
- The site should foreground the ongoing projects and philosophy (notably Atlas and Drifting Forms) so visitors first learn who Kris is and what he's working on. 
- The Shop should be a destination that follows story and context, not the dominant homepage affordance.

### Description
- Replace homepage content with an identity-led hero and three-panel layout (`index.md`) highlighting `Current focus`, `Recent work`, and `Explore` destinations. 
- Add a public `Atlas` page at `atlas/index.md` that documents the long-lived personal infrastructure philosophy without exposing private data. 
- Add an `Artwork` page at `artwork/index.md` that frames Drifting Forms as a human–machine collaboration and links to the shop as a downstream action. 
- Update shared layout and styles in `_layouts/default.html` to support the new hero variant, feature panels, focus/evidence card components, responsive grids, and top navigation links. 
- Update site metadata in `_config.yml` to match the new positioning (`description`).

### Testing
- Verified template sanity and local navigation targets with a small HTML-parse script (`python3` parsing of templates), which succeeded. 
- Ran `git diff --check` and `git diff --cached --check` to ensure no whitespace or staged errors, which passed. 
- Attempted `bundle exec jekyll build` but it could not run because dependency installation failed (Rubygems access returned `403 Forbidden`), so site build was not completed. 
- Attempted an automated page screenshot via `npx --yes playwright@latest` but it failed due to npm registry access returning `403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c744b17088327a37862940e9f52d1)